### PR TITLE
Update xkcdViewer provider to use HTTPS URLs

### DIFF
--- a/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicDefinition.java
+++ b/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicDefinition.java
@@ -25,7 +25,7 @@ public class XkcdComicDefinition implements IComicDefinition {
     
     @Override
     public Uri getArchiveUrl() {
-        return Uri.parse("http://xkcd.com/archive/");
+        return Uri.parse("https://xkcd.com/archive/");
     }
 
     @Override
@@ -35,7 +35,7 @@ public class XkcdComicDefinition implements IComicDefinition {
 
     @Override
     public Uri getAuthorLinkUrl() {
-        return Uri.parse("http://store.xkcd.com/");
+        return Uri.parse("https://store.xkcd.com/");
     }
 
     @Override

--- a/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicInfo.java
+++ b/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicInfo.java
@@ -48,7 +48,7 @@ public class XkcdComicInfo implements IComicInfo {
 
     @Override
     public String getUrl() {
-        return "http://xkcd.com/"+getId()+"/";
+        return "https://xkcd.com/"+getId()+"/";
     }
 
     @Override

--- a/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicProvider.java
+++ b/xkcdViewer/src/main/java/net/bytten/xkcdviewer/XkcdComicProvider.java
@@ -24,7 +24,7 @@ public class XkcdComicProvider implements IComicProvider {
     private static final Pattern archiveItemPattern = Pattern.compile(
             // group(1): comic number;   group(2): date;   group(3): title
             "\\s*<a href=\"/(\\d+)/\" title=\"(\\d+-\\d+-\\d+)\">([^<]+)</a><br/>\\s*");
-    private static final String ARCHIVE_URL = "http://www.xkcd.com/archive/";
+    private static final String ARCHIVE_URL = "https://www.xkcd.com/archive/";
     
     private XkcdComicDefinition def;
     
@@ -43,13 +43,13 @@ public class XkcdComicProvider implements IComicProvider {
 
     @Override
     public Uri createComicUrl(String comicId) {
-        return Uri.parse("http://xkcd.com/"+comicId+"/info.0.json");
+        return Uri.parse("https://xkcd.com/"+comicId+"/info.0.json");
     }
 
     @Override
     public IComicInfo fetchComicInfo(Uri url) throws Exception {
         // Uses xkcd's JSON interface
-        //      (http://xkcd.com/json.html) 
+        //      (https://xkcd.com/json.html) 
         String text = Utility.blockingReadUri(url);
         JSONObject obj = (JSONObject)new JSONTokener(text).nextValue();
         Log.d("json", obj.names().toString());
@@ -91,7 +91,7 @@ public class XkcdComicProvider implements IComicProvider {
 
     @Override
     public Uri getFinalComicUrl() {
-        return Uri.parse("http://xkcd.com/info.0.json");
+        return Uri.parse("https://xkcd.com/info.0.json");
     }
 
     @Override

--- a/xkcdViewer/src/main/res/values/strings.xml
+++ b/xkcdViewer/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     xkcdViewer v%s. Application for viewing xkcd comics with hover text.\n\n
     xkcdViewer Copyright (C) 2009-2017, Tom Coxon, Tyler Breisacher, David
     McCullough, Kristian Lundkvist.\n\n
-    xkcd is Copyright (C) 2006 - 2017, Randall Munroe (http://xkcd.com)\n\n
+    xkcd is Copyright (C) 2006 - 2017, Randall Munroe (https://xkcd.com)\n\n
     Contains some menu icons from www.androidicons.com, licensed under a
     Creative Commons Attribution - Share Alike license.\n\n
     Application icon kindly donated by Johan Larsson.\n\n


### PR DESCRIPTION
xkcd.com changed to using HTTPS some time ago; the change causes XkcdViewer to fail with "Data returned from website didn't match expected format" as the 301 redirect is attempted to be parsed as JSON, which obviously fails.

While this isn't a complete fix, it should hopefully fix the app enough for it to work again.

Fixes #70.

---

(Please note that I have not been able to test this as I do not have the correct build environment. I believe that my changes are correct, however!)